### PR TITLE
Feature/scop 467 ottobock rsyslog

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -8,9 +8,9 @@ echo "Building Docker Base Image for '$THIS_CONTAINER' - '$THIS_ARCH'"
 DOCKER_TAG=$(grep FROM containers/$THIS_CONTAINER/Dockerfile | tail -n 1 | cut -d : -f 2)-git$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION  | cut -c1-7)
 echo "DockerTag: $DOCKER_TAG"
 # pull previous container to allow layer cache
-docker pull motesque/$THIS_CONTAINER-$THIS_ARCH-debian:latest || echo "Unable to pull latest image! This is ok..."
-docker build -t motesque/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG} --cache-from motesque/$THIS_CONTAINER-$THIS_ARCH-debian:latest --build-arg ARCH=$THIS_ARCH  containers/$THIS_CONTAINER/
+docker pull base-images/$THIS_CONTAINER-$THIS_ARCH-debian:latest || echo "Unable to pull latest image! This is ok..."
+docker build -t base-images/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG} --cache-from base-images/$THIS_CONTAINER-$THIS_ARCH-debian:latest --build-arg ARCH=$THIS_ARCH  containers/$THIS_CONTAINER/
 
 
 #echo "Saving Docker Base Image for '$THIS_CONTAINER' - '$THIS_ARCH'"
-#docker save motesque/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG} | gzip > motesque-$THIS_CONTAINER-$THIS_ARCH-debian_latest.tar.gz
+#docker save base-images/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG} | gzip > motesque-$THIS_CONTAINER-$THIS_ARCH-debian_latest.tar.gz

--- a/automation/jenkins_publish.sh
+++ b/automation/jenkins_publish.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 THIS_ARCH=$1
 THIS_CONTAINER=$2
-export REPO_BASE=473689091316.dkr.ecr.eu-central-1.amazonaws.com/base-images
+export REPO_BASE=473689091316.dkr.ecr.eu-central-1.amazonaws.com
 
 # use the last entry as the TAG
 DOCKER_TAG=$(grep FROM containers/$THIS_CONTAINER/Dockerfile | tail -n 1 | cut -d : -f 2)-git$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION  | cut -c1-7)
 echo "Pushing Docker Base Image for '$THIS_CONTAINER' - '$THIS_ARCH'"
-docker push motesque/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG}
+docker push base-images/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG}
 # push again with latest tag
-docker tag motesque/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG} motesque/$THIS_CONTAINER-$THIS_ARCH-debian:latest
-docker push motesque/$THIS_CONTAINER-$THIS_ARCH-debian:latest
+docker tag base-images/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG} base-images/$THIS_CONTAINER-$THIS_ARCH-debian:latest
+docker push base-images/$THIS_CONTAINER-$THIS_ARCH-debian:latest
 # push to ECR:
-docker tag motesque/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG} ${REPO_BASE}/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG}
-docker tag motesque/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG} ${REPO_BASE}/$THIS_CONTAINER-$THIS_ARCH-debian:latest
-docker push ${REPO_BASE}/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG}
-docker push ${REPO_BASE}/$THIS_CONTAINER-$THIS_ARCH-debian:latest
+docker tag base-images/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG} ${REPO_BASE}/base-images/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG}
+docker tag base-images/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG} ${REPO_BASE}/base-images/$THIS_CONTAINER-$THIS_ARCH-debian:latest
+docker push ${REPO_BASE}/base-images/$THIS_CONTAINER-$THIS_ARCH-debian:${DOCKER_TAG}
+docker push ${REPO_BASE}/base-images/$THIS_CONTAINER-$THIS_ARCH-debian:latest

--- a/containers/ottobock/Dockerfile
+++ b/containers/ottobock/Dockerfile
@@ -49,6 +49,9 @@ RUN install_packages \
 COPY --from=build /usr/local/lib/rsyslog /usr/local/lib/rsyslog
 COPY --from=build /usr/local/sbin/rsyslogd /usr/local/sbin
 
+RUN echo "/usr/local/lib/rsyslog" >/etc/ld.so.conf.d/rsyslog-libs.conf && \
+    ldconfig
+
 RUN ["/bin/bash", "-c", "if [ $ARCH != 'amd64' ]; then cross-build-start; fi"]
 RUN set -e \
     && wget  -nv https://nyc3-download-01.motesque.com/packages/Python-$PYTHON_VERSION.linux-$ARCH.tar.gz \

--- a/containers/ottobock/Dockerfile
+++ b/containers/ottobock/Dockerfile
@@ -54,6 +54,7 @@ COPY rsyslog/rsyslog /etc/init.d/rsyslog
 
 RUN chmod +x /etc/init.d/rsyslog && \
     mkdir -p /etc/rsyslog.d && \
+    mkdir -p /var/spool/rsyslog && \
     useradd -U -G adm syslog && \
     echo "/usr/local/lib/rsyslog" >/etc/ld.so.conf.d/rsyslog-libs.conf && \
     ldconfig

--- a/containers/ottobock/Dockerfile
+++ b/containers/ottobock/Dockerfile
@@ -49,7 +49,13 @@ RUN install_packages \
 COPY --from=build /usr/local/lib/rsyslog /usr/local/lib/rsyslog
 COPY --from=build /usr/local/sbin/rsyslogd /usr/local/sbin
 
-RUN echo "/usr/local/lib/rsyslog" >/etc/ld.so.conf.d/rsyslog-libs.conf && \
+COPY rsyslog/rsyslog.conf /etc/rsyslog.conf
+COPY rsyslog/rsyslog /etc/init.d/rsyslog
+
+RUN chmod +x /etc/init.d/rsyslog && \
+    mkdir -p /etc/rsyslog.d && \
+    useradd -U -G adm syslog && \
+    echo "/usr/local/lib/rsyslog" >/etc/ld.so.conf.d/rsyslog-libs.conf && \
     ldconfig
 
 RUN ["/bin/bash", "-c", "if [ $ARCH != 'amd64' ]; then cross-build-start; fi"]

--- a/containers/ottobock/Dockerfile
+++ b/containers/ottobock/Dockerfile
@@ -21,7 +21,7 @@ RUN set -e && \
     wget https://www.rsyslog.com/files/download/rsyslog/rsyslog-8.2102.0.tar.gz && \
     tar -xvzf rsyslog-8.2102.0.tar.gz && \
     cd rsyslog-8.2102.0 && \
-    ./configure --enable-omhttp && \
+    ./configure --enable-omhttp --enable-imfile && \
     make && \
     make install
 
@@ -35,6 +35,7 @@ RUN install_packages \
     less \
     libfastjson4 \
     libestr0 \
+    libcurl3-gnutls \
     libcairo2  \
     libpango-1.0-0  \
     libpangocairo-1.0-0  \

--- a/containers/ottobock/Dockerfile
+++ b/containers/ottobock/Dockerfile
@@ -1,4 +1,31 @@
 ARG ARCH
+FROM balenalib/$ARCH-debian:buster-build-20200502 as build
+
+RUN install_packages \
+    wget \
+    gcc \
+    make \
+    libc-dev \
+    pkg-config \
+    libestr-dev \
+    libfastjson-dev \
+    zlib1g-dev \
+    uuid-dev \
+    libgcrypt20-dev \
+    libcurl4-gnutls-dev \
+    wget
+
+RUN set -e && \
+    mkdir /rsyslog && \
+    cd /rsyslog && \
+    wget https://www.rsyslog.com/files/download/rsyslog/rsyslog-8.2102.0.tar.gz && \
+    tar -xvzf rsyslog-8.2102.0.tar.gz && \
+    cd rsyslog-8.2102.0 && \
+    ./configure --enable-omhttp && \
+    make && \
+    make install
+
+ARG ARCH
 FROM balenalib/$ARCH-debian:buster-run-20200502
 ARG ARCH
 ENV PYTHON_VERSION=3.8.2
@@ -6,6 +33,8 @@ ENV PYTHON_VERSION=3.8.2
 RUN install_packages \
     cron \
     less \
+    libfastjson4 \
+    libestr0 \
     libcairo2  \
     libpango-1.0-0  \
     libpangocairo-1.0-0  \
@@ -15,6 +44,9 @@ RUN install_packages \
     openssh-client \
     vim \
     wget
+
+COPY --from=build /usr/local/lib/rsyslog /usr/local/lib/rsyslog
+COPY --from=build /usr/local/sbin/rsyslogd /usr/local/sbin
 
 RUN ["/bin/bash", "-c", "if [ $ARCH != 'amd64' ]; then cross-build-start; fi"]
 RUN set -e \
@@ -41,9 +73,3 @@ RUN install_packages cabextract xfonts-utils \
 
 RUN dpkg-query -W -f '${binary:Package},${Version},${binary:Summary}\n' > /usr/local/lib/_stage_debian_packages.csv
 RUN ["/bin/bash", "-c", "if [ $ARCH != 'amd64' ]; then cross-build-end; fi"]
-
-# 2nd tier dependecies
-RUN install_packages \
-       rsyslog  \
-       rsyslog-gnutls \
-       rsyslog-omhttp

--- a/containers/ottobock/Dockerfile
+++ b/containers/ottobock/Dockerfile
@@ -43,7 +43,7 @@ RUN dpkg-query -W -f '${binary:Package},${Version},${binary:Summary}\n' > /usr/l
 RUN ["/bin/bash", "-c", "if [ $ARCH != 'amd64' ]; then cross-build-end; fi"]
 
 # 2nd tier dependecies
-RUN install_packages
+RUN install_packages \
        rsyslog  \
        rsyslog-gnutls \
        rsyslog-omhttp

--- a/containers/ottobock/Dockerfile
+++ b/containers/ottobock/Dockerfile
@@ -41,3 +41,9 @@ RUN install_packages cabextract xfonts-utils \
 
 RUN dpkg-query -W -f '${binary:Package},${Version},${binary:Summary}\n' > /usr/local/lib/_stage_debian_packages.csv
 RUN ["/bin/bash", "-c", "if [ $ARCH != 'amd64' ]; then cross-build-end; fi"]
+
+# 2nd tier dependecies
+RUN install_packages
+       rsyslog  \
+       rsyslog-gnutls \
+       rsyslog-omhttp

--- a/containers/ottobock/rsyslog/50-default.conf
+++ b/containers/ottobock/rsyslog/50-default.conf
@@ -1,0 +1,48 @@
+#  Default rules for rsyslog.
+#
+#			For more information see rsyslog.conf(5) and /etc/rsyslog.conf
+
+#
+# First some standard log files.  Log by facility.
+#
+auth,authpriv.*			/var/log/auth.log
+*.*;auth,authpriv.none		-/var/log/syslog
+#cron.*				/var/log/cron.log
+#daemon.*			-/var/log/daemon.log
+kern.*				-/var/log/kern.log
+#lpr.*				-/var/log/lpr.log
+mail.*				-/var/log/mail.log
+#user.*				-/var/log/user.log
+
+#
+# Logging for the mail system.  Split it up so that
+# it is easy to write scripts to parse these files.
+#
+#mail.info			-/var/log/mail.info
+#mail.warn			-/var/log/mail.warn
+mail.err			/var/log/mail.err
+
+#
+# Some "catch-all" log files.
+#
+#*.=debug;\
+#	auth,authpriv.none;\
+#	news.none;mail.none	-/var/log/debug
+#*.=info;*.=notice;*.=warn;\
+#	auth,authpriv.none;\
+#	cron,daemon.none;\
+#	mail,news.none		-/var/log/messages
+
+#
+# Emergencies are sent to everybody logged in.
+#
+*.emerg				:omusrmsg:*
+
+#
+# I like to have messages displayed on the console, but only on a virtual
+# console I usually leave idle.
+#
+#daemon,mail.*;\
+#	news.=crit;news.=err;news.=notice;\
+#	*.=debug;*.=info;\
+#	*.=notice;*.=warn	/dev/tty8

--- a/containers/ottobock/rsyslog/rsyslog
+++ b/containers/ottobock/rsyslog/rsyslog
@@ -51,7 +51,8 @@ do_stop()
 	#   0 if daemon has been stopped
 	#   1 if daemon was already stopped
 	#   other if daemon could not be stopped or a failure occurred
-	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --exec $DAEMON
+	#start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --exec $DAEMON
+	ps -ef | grep rsyslogd | grep -v grep | awk '{ print $2 }' | xargs kill -9 && rm -f ${PIDFILE}
 }
 
 #

--- a/containers/ottobock/rsyslog/rsyslog
+++ b/containers/ottobock/rsyslog/rsyslog
@@ -1,0 +1,129 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          rsyslog
+# Required-Start:    $remote_fs $time
+# Required-Stop:     umountnfs $time
+# X-Stop-After:      sendsigs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: enhanced syslogd
+# Description:       Rsyslog is an enhanced multi-threaded syslogd.
+#                    It is quite compatible to stock sysklogd and can be
+#                    used as a drop-in replacement.
+### END INIT INFO
+
+#
+# Author: Michael Biebl <biebl@debian.org>
+#
+
+# PATH should only include /usr/* if it runs after the mountnfs.sh script
+PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/sbin
+DESC="enhanced syslogd"
+NAME=rsyslog
+
+RSYSLOGD=rsyslogd
+DAEMON=/usr/local/sbin/rsyslogd
+PIDFILE=/run/rsyslogd.pid
+
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Define LSB log_* functions.
+. /lib/lsb/init-functions
+
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   other if daemon could not be started or a failure occured
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- $RSYSLOGD_OPTIONS
+}
+
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   other if daemon could not be stopped or a failure occurred
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --exec $DAEMON
+}
+
+#
+# Tell rsyslogd to close all open files
+#
+do_rotate() {
+	start-stop-daemon --stop --signal HUP --quiet --pidfile $PIDFILE --exec $DAEMON
+}
+
+create_xconsole() {
+	XCONSOLE=/dev/xconsole
+	if [ "$(uname -s)" != "Linux" ]; then
+		XCONSOLE=/run/xconsole
+		ln -sf $XCONSOLE /dev/xconsole
+	fi
+	if [ ! -e $XCONSOLE ]; then
+		mknod -m 640 $XCONSOLE p
+		chown root:adm $XCONSOLE
+		[ -x /sbin/restorecon ] && /sbin/restorecon $XCONSOLE
+	fi
+}
+
+sendsigs_omit() {
+	OMITDIR=/run/sendsigs.omit.d
+	mkdir -p $OMITDIR
+	ln -sf $PIDFILE $OMITDIR/rsyslog
+}
+
+case "$1" in
+  start)
+	log_daemon_msg "Starting $DESC" "$RSYSLOGD"
+	create_xconsole
+	do_start
+	case "$?" in
+		0) sendsigs_omit
+		   log_end_msg 0 ;;
+		1) log_progress_msg "already started"
+		   log_end_msg 0 ;;
+		*) log_end_msg 1 ;;
+	esac
+
+	;;
+  stop)
+	log_daemon_msg "Stopping $DESC" "$RSYSLOGD"
+	do_stop
+	case "$?" in
+		0) log_end_msg 0 ;;
+		1) log_progress_msg "already stopped"
+		   log_end_msg 0 ;;
+		*) log_end_msg 1 ;;
+	esac
+
+	;;
+  rotate)
+	log_daemon_msg "Closing open files" "$RSYSLOGD"
+	do_rotate
+	log_end_msg $?
+	;;
+  restart|force-reload)
+	$0 stop
+	$0 start
+	;;
+  try-restart)
+	$0 status >/dev/null 2>&1 && $0 restart
+	;;
+  status)
+	status_of_proc -p $PIDFILE $DAEMON $RSYSLOGD && exit 0 || exit $?
+	;;
+  *)
+	echo "Usage: $SCRIPTNAME {start|stop|rotate|restart|force-reload|try-restart|status}" >&2
+	exit 3
+	;;
+esac
+
+:

--- a/containers/ottobock/rsyslog/rsyslog.conf
+++ b/containers/ottobock/rsyslog/rsyslog.conf
@@ -1,0 +1,59 @@
+#  /etc/rsyslog.conf	Configuration file for rsyslog.
+#
+#			For more information see
+#			/usr/share/doc/rsyslog-doc/html/rsyslog_conf.html
+#
+#  Default logging rules can be found in /etc/rsyslog.d/50-default.conf
+
+
+#################
+#### MODULES ####
+#################
+
+module(load="imuxsock") # provides support for local system logging
+#module(load="immark")  # provides --MARK-- message capability
+
+# provides UDP syslog reception
+#module(load="imudp")
+#input(type="imudp" port="514")
+
+# provides TCP syslog reception
+#module(load="imtcp")
+#input(type="imtcp" port="514")
+
+# provides kernel logging support and enable non-kernel klog messages
+# module(load="imklog" permitnonkernelfacility="on")
+
+###########################
+#### GLOBAL DIRECTIVES ####
+###########################
+
+#
+# Use traditional timestamp format.
+# To enable high precision timestamps, comment out the following line.
+#
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+# Filter duplicated messages
+$RepeatedMsgReduction on
+
+#
+# Set the default permissions for all log files.
+#
+$FileOwner syslog
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+$PrivDropToUser syslog
+$PrivDropToGroup syslog
+
+#
+# Where to place spool and state files
+#
+$WorkDirectory /var/spool/rsyslog
+
+#
+# Include all config files in /etc/rsyslog.d/
+#
+$IncludeConfig /etc/rsyslog.d/*.conf


### PR DESCRIPTION
Please see https://motesque.atlassian.net/browse/SCOP-467 for details.

This add rsyslog and the omhttp module to the Ottobock base_image. It needs to be compiled from source because the omhttp module isn't currently available as a package for Debian 10 on arm. 
