### PR TITLE
Remove isort and black (dev tools) from base image

### DIFF
--- a/containers/scopethemove/requirements.txt
+++ b/containers/scopethemove/requirements.txt
@@ -1,5 +1,6 @@
 Automat==0.8.0
 CairoSVG==2.4.2
+Click==7.0
 Cython==0.29.21
 Flask-WTF==0.14.2
 Flask==1.1.1
@@ -27,7 +28,6 @@ aiohttp-middlewares==1.1.0
 aiohttp-sse==2.0.0
 aiohttp-tus==1.0.0
 aiohttp==3.6.2
-appdirs==1.4.4
 argh==0.26.2
 async-timeout==3.0.1
 attrs==21.2.0
@@ -35,7 +35,6 @@ autobahn==19.10.1
 awscli==1.18.133
 bcrypt==3.1.7
 bitstring==3.1.6
-black==21.5b1
 boto3==1.14.56
 botocore==1.17.56
 brotlipy==0.7.0
@@ -44,7 +43,6 @@ cbor==1.0.0
 certifi==2020.6.20
 cffi==1.14.1
 chardet==3.0.4
-click==7.1.2
 colorama==0.4.1
 constantly==15.1.0
 croniter==0.3.30
@@ -74,7 +72,6 @@ idna-ssl==1.1.0
 idna==2.5
 incremental==17.5.0
 iniconfig==1.1.1
-isort==5.8.0
 itsdangerous==1.1.0
 jmespath==0.9.4
 joblib==0.14.0
@@ -87,7 +84,6 @@ mistune==0.8.4
 mock==4.0.2
 msgpack==1.0.0
 multidict==4.7.6
-mypy-extensions==0.4.3
 netaddr==0.7.19
 netifaces==0.10.9
 numba==0.49.1
@@ -95,7 +91,6 @@ numpy==1.19.1
 packaging==20.9
 pandas==1.1.2
 passlib==1.7.1
-pathspec==0.8.1
 pathtools==0.1.2
 pluggy==0.13.1
 priority==1.3.0
@@ -122,7 +117,6 @@ python4yahdlc==1.2.0
 pytz==2019.3
 pyudev==0.22.0
 qrcode[pil]==6.1
-regex==2021.4.4
 reportlab==3.5.46
 requests==2.22.0
 rfc3986==1.4.0


### PR DESCRIPTION
`black` and `isort` are development tools, thus should not be part of base image.